### PR TITLE
ol.View2D is now ol.View

### DIFF
--- a/src/bing.html
+++ b/src/bing.html
@@ -29,7 +29,7 @@
             })
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
           zoom: 9
         })

--- a/src/doc/basics/dissect.rst
+++ b/src/doc/basics/dissect.rst
@@ -65,7 +65,7 @@ The next step in generating your map is to include some initialization code. In 
             })
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [0, 0],
           zoom: 0,
@@ -113,7 +113,7 @@ The final step is defining the view. We specify a projection, a center and a zoo
 
 .. code-block:: javascript
 
-    view: new ol.View2D({
+    view: new ol.View({
        projection: 'EPSG:4326',
        center: [0, 0],
        zoom: 0,

--- a/src/doc/basics/map.rst
+++ b/src/doc/basics/map.rst
@@ -43,7 +43,7 @@ Let's take a look at a fully working example of an OpenLayers 3 map.
                 })
               })
             ],
-            view: new ol.View2D({
+            view: new ol.View({
               projection: 'EPSG:4326',
               center: [0, 0],
               zoom: 0,

--- a/src/doc/controls/draw.rst
+++ b/src/doc/controls/draw.rst
@@ -66,7 +66,7 @@ Create a Vector Layer and a Draw Interaction
                     })
                   })
                 ],
-                view: new ol.View2D({
+                view: new ol.View({
                   projection: 'EPSG:4326',
                   center: [0, 0],
                   zoom: 1

--- a/src/doc/controls/modify.rst
+++ b/src/doc/controls/modify.rst
@@ -79,7 +79,7 @@ Create a Vector Layer and a Modify Interaction
                     })
                   })
                 ],
-                view: new ol.View2D({
+                view: new ol.View({
                   projection: 'EPSG:4326',
                   center: [0, 0],
                   zoom: 1

--- a/src/doc/controls/select.rst
+++ b/src/doc/controls/select.rst
@@ -77,7 +77,7 @@ Create a Vector Layer and a Select Interaction
                     })
                   })
                 ],
-                view: new ol.View2D({
+                view: new ol.View({
                   projection: 'EPSG:4326',
                   center: [0, 0],
                   zoom: 1

--- a/src/doc/layers/cached.rst
+++ b/src/doc/layers/cached.rst
@@ -42,7 +42,7 @@ The `OpenStreetMap (OSM) <http://www.openstreetmap.org/>`_ project is an effort 
                 source: new ol.source.OSM()
               })
             ],
-            view: new ol.View2D({
+            view: new ol.View({
               center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
               zoom: 9
             })
@@ -79,7 +79,7 @@ Review the view definition of the map:
 
 .. code-block:: javascript
 
-    view: new ol.View2D({
+    view: new ol.View({
       center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
       zoom: 9
     })

--- a/src/doc/layers/imagevector.rst
+++ b/src/doc/layers/imagevector.rst
@@ -51,7 +51,7 @@ Let's go back to the vector layer example to get earthquake data on top of a wor
                 })
               })
             })],
-            view: new ol.View2D({
+            view: new ol.View({
               projection: 'EPSG:4326',
               center: [0, 0],
               zoom: 0,

--- a/src/doc/layers/proprietary.rst
+++ b/src/doc/layers/proprietary.rst
@@ -73,7 +73,7 @@ Your revised ``map.html`` file should look something like this:
               })
             })
           ],
-          view: new ol.View2D({
+          view: new ol.View({
             center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
             zoom: 9
           })

--- a/src/doc/layers/vector.rst
+++ b/src/doc/layers/vector.rst
@@ -41,7 +41,7 @@ Let's go back to the WMS example to get a basic world map.  We'll add some featu
                 })
               })
             ],
-            view: new ol.View2D({
+            view: new ol.View({
               projection: 'EPSG:4326',
               center: [0, 0],
               zoom: 0,

--- a/src/doc/layers/wms.rst
+++ b/src/doc/layers/wms.rst
@@ -55,7 +55,7 @@ Let's take a look at the following code:
                 })
               })
             ],
-            view: new ol.View2D({
+            view: new ol.View({
               projection: 'EPSG:4326',
               center: [0, 0],
               zoom: 0,

--- a/src/doc/vector-style/style.rst
+++ b/src/doc/vector-style/style.rst
@@ -39,7 +39,7 @@ Styling Vector Layers
                     })
                   })
                 ],
-                view: new ol.View2D({
+                view: new ol.View({
                   projection: 'EPSG:4326',
                   center: [-122.791859392, 42.3099154789],
                   zoom: 16

--- a/src/map.html
+++ b/src/map.html
@@ -27,7 +27,7 @@
             })
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [0, 0],
           zoom: 0,

--- a/src/osm.html
+++ b/src/osm.html
@@ -26,7 +26,7 @@
             source: new ol.source.OSM()
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
           zoom: 9
         })

--- a/src/scaleline.html
+++ b/src/scaleline.html
@@ -38,7 +38,7 @@
             })
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [0, 0],
           zoom: 1

--- a/src/select.html
+++ b/src/select.html
@@ -69,7 +69,7 @@
             }
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [0, 0],
           zoom: 1

--- a/src/style.html
+++ b/src/style.html
@@ -42,7 +42,7 @@
             }
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [-122.791859392, 42.3099154789],
           zoom: 16

--- a/src/vector.html
+++ b/src/vector.html
@@ -45,7 +45,7 @@
             }
           })
         ],
-        view: new ol.View2D({
+        view: new ol.View({
           projection: 'EPSG:4326',
           center: [0, 0],
           zoom: 1


### PR DESCRIPTION
This PR changes every occurrence of `ol.View2D` to `ol.View`. I still need to update `ol-whitespace.js` (actually replace it by `ol-debug.js`) and `ol.js` but I'll do that as a separate PR, possibly after the release. 
